### PR TITLE
Exclude .env from docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ node_moduels
 ssb-go-room-secrets
 ssb-go-room-secrets/**/*
 .git
+.env


### PR DESCRIPTION
This fixes an issue where environment variables could be ignored by `start.sh` when running in Docker.

Before this change `.env` would be copied into the docker image if it exists in the repository. Because `start.sh` gives precedence to the `.env` file over actual environment variables, if you then changed the environment variables in `.env` they wouldn't be picked up by `go-ssb-room`.