### PR TITLE
Add a listAliases muxrpc endpoint

### DIFF
--- a/muxrpc/handlers/alias/handler.go
+++ b/muxrpc/handlers/alias/handler.go
@@ -167,11 +167,7 @@ func (h Handler) List(ctx context.Context, req *muxrpc.Request) (interface{}, er
 
 	allAliases, err := h.db.List(ctx)
 	if err != nil {
-		var takenErr roomdb.ErrAliasTaken
-		if errors.As(err, &takenErr) {
-			return nil, takenErr
-		}
-		return nil, fmt.Errorf("listAlias: could not register alias: %w", err)
+		return nil, fmt.Errorf("listAlias: could not list aliases: %w", err)
 	}
 
 	var filteredAliases []roomdb.Alias

--- a/muxrpc/handlers/alias/handler.go
+++ b/muxrpc/handlers/alias/handler.go
@@ -147,3 +147,47 @@ func (h Handler) Revoke(ctx context.Context, req *muxrpc.Request) (interface{}, 
 
 	return true, nil
 }
+
+func (h Handler) List(ctx context.Context, req *muxrpc.Request) (interface{}, error) {
+	var args []string
+
+	err := json.Unmarshal(req.RawArgs, &args)
+	if err != nil {
+		return nil, fmt.Errorf("listAlias: bad request: %w", err)
+	}
+
+	if n := len(args); n != 1 {
+		return nil, fmt.Errorf("listAlias: expected one argument got %d", n)
+	}
+
+	ref, err := refs.ParseFeedRef(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("listAlias: invalid feed ref: %w", err)
+	}
+
+	allAliases, err := h.db.List(ctx)
+	if err != nil {
+		var takenErr roomdb.ErrAliasTaken
+		if errors.As(err, &takenErr) {
+			return nil, takenErr
+		}
+		return nil, fmt.Errorf("listAlias: could not register alias: %w", err)
+	}
+
+	var filteredAliases []roomdb.Alias
+	for _, alias := range allAliases {
+		if alias.Feed.Equal(ref) {
+			filteredAliases = append(filteredAliases, alias)
+		}
+	}
+
+	return aliasesToListOfAliasStrings(filteredAliases), nil
+}
+
+func aliasesToListOfAliasStrings(aliases []roomdb.Alias) []string {
+	result := make([]string, 0)
+	for _, alias := range aliases {
+		result = append(result, alias.Name)
+	}
+	return result
+}

--- a/roomsrv/init_handlers.go
+++ b/roomsrv/init_handlers.go
@@ -61,6 +61,7 @@ func (s *Server) initHandlers() {
 		var method = muxrpc.Method{"room"}
 		mux.RegisterAsync(append(method, "registerAlias"), typemux.AsyncFunc(aliasHandler.Register))
 		mux.RegisterAsync(append(method, "revokeAlias"), typemux.AsyncFunc(aliasHandler.Revoke))
+		mux.RegisterAsync(append(method, "listAliases"), typemux.AsyncFunc(aliasHandler.List))
 
 		method = muxrpc.Method{"httpAuth"}
 		mux.RegisterAsync(append(method, "invalidateAllSolutions"), typemux.AsyncFunc(siwssbHandler.InvalidateAllSolutions))

--- a/roomsrv/manifest.go
+++ b/roomsrv/manifest.go
@@ -41,6 +41,7 @@ const manifest manifestHandler = `
 	"room": {
 		"registerAlias": "async",
 		"revokeAlias": "async",
+		"listAliases": "async",
 
 		"connect": "duplex",
 		"attendants": "source",


### PR DESCRIPTION
I would like to get some feedback on adding a function similar to this one. This would make it possible to retrieve a list of all aliases for a particular user. This list could be used by users to preview their aliases without using the web interface.