### PR TITLE
feat: armhf/arm64 & including insert-user

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,8 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - id: go-ssb-room-linux-amd64
+    env:
       # needed for sqlite
       - CGO_ENABLED=1
     main: ./cmd/server
@@ -19,11 +20,82 @@ builds:
     goarch:
       - amd64
 
+  - id: go-ssb-room-insert-user-linux-amd64
+    env:
+      # needed for sqlite
+      - CGO_ENABLED=1
+    main: ./cmd/insert-user
+    binary: go-ssb-room-insert-user
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+  - id: go-ssb-room-linux-arm64
+    env:
+      # needed for sqlite
+      - CGO_ENABLED=1
+      # cross-compilation
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    main: ./cmd/server
+    binary: go-ssb-room
+    goos:
+      - linux
+    goarch:
+      - arm64
+
+  - id: go-ssb-room-insert-user-linux-arm64
+    env:
+      # needed for sqlite
+      - CGO_ENABLED=1
+      # cross-compilation
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    main: ./cmd/insert-user
+    binary: go-ssb-room-insert-user
+    goos:
+      - linux
+    goarch:
+      - arm64
+
+  - id: go-ssb-room-linux-armhf
+    env:
+      # needed for sqlite
+      - CGO_ENABLED=1
+      # cross-compilation
+      - CC=arm-linux-gnueabihf-gcc
+      - CXX=arm-linux-gnueabihf--g++
+    main: ./cmd/server
+    binary: go-ssb-room
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+      - 7
+
+  - id: go-ssb-room-insert-user-linux-armhf
+    env:
+      # needed for sqlite
+      - CGO_ENABLED=1
+      # cross-compilation
+      - CC=arm-linux-gnueabihf-gcc
+      - CXX=arm-linux-gnueabihf--g++
+    main: ./cmd/insert-user
+    binary: go-ssb-room-insert-user
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+      - 7
+
 gomod:
-  # sum.golang.org somehow doesn't handle replace as expected. TODO: file issue
-  proxy: false
   env:
-    - GOPROXY=https://proxy.golang.org,direct
+    - GOPROXY=https://proxy.golang.org
     - GOSUMDB=sum.golang.org
 
 # for .deb packages
@@ -31,9 +103,6 @@ gomod:
 nfpms:
  - id: go-ssb-room
    package_name: go-ssb-room
-   replacements:
-     linux: Linux
-     amd64: x86_64
    vendor: Secure-Scuttlebutt Community
    maintainer: Go-SSB-Room NGI-Pointer Team <go-ssb-room@ssb-ngi-pointer.email>
    homepage: https://scuttlebutt.nz
@@ -44,9 +113,10 @@ nfpms:
    suggests:
      - ngingx
      - certbot
-   empty_folders:
-     - /var/log/go-ssb-room
    contents:
+     - dst: /var/log/go-ssb-room
+       type: dir
+
      - src: docs/files/example-systemd.service
        dst: /etc/systemd/system/go-ssb-room.service
        type: "config|noreplace"
@@ -64,9 +134,7 @@ nfpms:
      preremove: docs/files/debian-preremove.sh
 
 archives:
-  - replacements:
-      linux: Linux
-      amd64: x86_64
+  - id: go-ssb-room
 
 checksum:
   name_template: 'checksums.txt'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,7 @@ We currently only distributed pre-packaged releases for Debian-compatible distri
 See [Issue #79](https://github.com/ssbc/go-ssb-room/issues/79) for the details.
 If this doesn't work for you, read the "Creating a build" section below.
 
-After running `sudo dpkg -i go-ssb-room_v1.2.3_Linux_x86_64.deb` pay special attention to the
+After running `sudo dpkg -i go-ssb-room_v1.2.3_linux_amd64.deb` pay special attention to the
 [postinstall notes](./files/debian-postinstall.sh) for how to configure the systemd file and webserver.
 
 ## Creating a build

--- a/docs/development.md
+++ b/docs/development.md
@@ -128,10 +128,12 @@ See the [testing.md](./testing.md) for a thorough walkthorugh of the different t
 
 Because of [issue #79](https://github.com/ssbc/go-ssb-room/issues/79) we can't simply create binaries for all platforms independantly. Therefore binaries for re-distributions need to be created on the relevant distributions themselvs. We currently do this for debian. The process is as follows:
 
-1) Install a recent debian stable version onto a dedicated machine or VM for instance (docker might also be possible).
-2) Install [Go](https://golang.org/doc/install).
-3) Install a C compiler (`sudo apt install gcc` for instance) for the CGo based sqlite dependency.
-4) Install [GoReleaser](https://goreleaser.com/install/).
-5) Create a version tag in git.
-6) run `goreleaser release` at the root of the repo to create the `dist/` folder with the `.deb` file.
-7) Upload the built packages.
+1. Install a recent debian stable version onto a dedicated machine or VM for instance (docker might also be possible).
+1. Install [Go](https://golang.org/doc/install).
+1. Install a C compiler (`sudo apt install gcc` for instance) for the CGo based sqlite dependency.
+1. Install a compiler which supports cross-compilation for ARM* architectures (`sudo apt install gccgo-aarch64-linux-gnu gccgo-arm-linux-gnueabihf`).
+1. Install Node.js v14 and install the dependencies (`cd ./web/styles && npm ci`, you may need to `npm install postcss` also).
+1. Install [GoReleaser](https://goreleaser.com/install/).
+1. Create a version tag in git.
+1. Run `goreleaser release` at the root of the repo to create the `dist/` folder with the `.deb` file.
+1. Upload the built packages.

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221020091224-b09bdf60812f
+	github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c
 	github.com/ssbc/go-netwrap v0.1.5-0.20221019160355-cd323bb2e29d
 	github.com/ssbc/go-secretstream v1.2.11-0.20221111164233-4b41f899f844
 	github.com/ssbc/go-ssb-refs v0.5.2-0.20221019090322-8b558c2f31de

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/spf13/viper v1.9.0/go.mod h1:+i6ajR7OX2XaiBkrcZJFK21htRk7eDeLg7+O6bhUPP4=
 github.com/ssbc/go-luigi v0.3.7-0.20221019204020-324065b9a7c6 h1:4Mhg4qHaiX56eXNND9gGJAf0xzoRQQtfFFhv6wcIOIU=
 github.com/ssbc/go-luigi v0.3.7-0.20221019204020-324065b9a7c6/go.mod h1:tBPMBysJeh1u3vStvrWe5w3YBC4fnbnGsLk5ML4D6do=
-github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221020091224-b09bdf60812f h1:eIzrej3VH9sYd13X8zVVzlsDRh0uCjYCbdsLcsZqrnc=
-github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221020091224-b09bdf60812f/go.mod h1:CFvV9kCI3SmJM38pf1NCXWrS7UVgTYXJdKs+Q9hkJIw=
+github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c h1:xqjaqcG0diMshLo0OaujvHE96OFrd/GiCTJYCTrPVhE=
+github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c/go.mod h1:CFvV9kCI3SmJM38pf1NCXWrS7UVgTYXJdKs+Q9hkJIw=
 github.com/ssbc/go-netwrap v0.1.5-0.20221019160355-cd323bb2e29d h1:UnYPPekKU0mHzMMOSuI6117Djq9xni60c/IzzUYxgCI=
 github.com/ssbc/go-netwrap v0.1.5-0.20221019160355-cd323bb2e29d/go.mod h1:tsE1qeqkc8kvf1psPNdJ5s8O+/jE1WlKwsEETb2VZqs=
 github.com/ssbc/go-secretstream v1.2.11-0.20221111164233-4b41f899f844 h1:r1uKQOpTliDf9BCMbRfCeynZ87Y+XMs/DBZqZzB596Y=

--- a/roomdb/interface.go
+++ b/roomdb/interface.go
@@ -19,6 +19,7 @@ import (
 	"go.mindeco.de/http/auth"
 )
 
+//counterfeiter:generate . RoomConfig
 type RoomConfig interface {
 	GetPrivacyMode(context.Context) (PrivacyMode, error)
 	SetPrivacyMode(context.Context, PrivacyMode) error
@@ -28,6 +29,7 @@ type RoomConfig interface {
 
 // AuthFallbackService allows password authentication which might be helpful for scenarios
 // where one lost access to his ssb device or key.
+//counterfeiter:generate . AuthFallbackService
 type AuthFallbackService interface {
 
 	// Check receives the username and password (in clear) and checks them accordingly.
@@ -48,6 +50,7 @@ type AuthFallbackService interface {
 // AuthWithSSBService defines utility functions for the challenge/response system of sign-in with ssb
 // They are particualarly of service to check valid sessions (after the client provided a solution for a challenge)
 // And to log out valid sessions from the clients device.
+//counterfeiter:generate . AuthWithSSBService
 type AuthWithSSBService interface {
 
 	// CreateToken is used to generate a token that is stored inside a cookie.
@@ -65,6 +68,7 @@ type AuthWithSSBService interface {
 }
 
 // MembersService stores and retreives the list of internal users (members, mods and admins).
+//counterfeiter:generate . MembersService
 type MembersService interface {
 	// Add adds a new member
 	Add(_ context.Context, pubKey refs.FeedRef, r Role) (int64, error)
@@ -95,6 +99,7 @@ type MembersService interface {
 }
 
 // DeniedKeysService changes the lists of public keys that are not allowed to get into the room
+//counterfeiter:generate . DeniedKeysService
 type DeniedKeysService interface {
 	// Add adds the feed to the list, together with a comment for other members
 	Add(ctx context.Context, ref refs.FeedRef, comment string) error
@@ -122,6 +127,7 @@ type DeniedKeysService interface {
 }
 
 // AliasesService manages alias handle registration and lookup
+//counterfeiter:generate . AliasesService
 type AliasesService interface {
 	// Resolve returns all the relevant information for that alias or an error if it doesnt exist
 	Resolve(context.Context, string) (Alias, error)
@@ -140,6 +146,7 @@ type AliasesService interface {
 }
 
 // InvitesService manages creation and consumption of invite tokens for joining the room.
+//counterfeiter:generate . InvitesService
 type InvitesService interface {
 	// Create creates a new invite for a new member. It returns the token or an error.
 	// createdBy is user ID of the admin or moderator who created it. MemberID -1 is allowed if Privacy Mode is set to Open.
@@ -169,6 +176,7 @@ type InvitesService interface {
 
 // PinnedNoticesService allows an admin to assign Notices to specific placeholder pages.
 // like updates, privacy policy, code of conduct
+//counterfeiter:generate . PinnedNoticesService
 type PinnedNoticesService interface {
 	// List returns a list of all the pinned notices with their corresponding notices and languages
 	List(context.Context) (PinnedNotices, error)
@@ -181,6 +189,7 @@ type PinnedNoticesService interface {
 }
 
 // NoticesService is the low level store to manage single notices
+//counterfeiter:generate . NoticesService
 type NoticesService interface {
 	// GetByID returns the page for that ID or an error
 	GetByID(context.Context, int64) (Notice, error)
@@ -191,23 +200,3 @@ type NoticesService interface {
 	// RemoveID removes the page for that ID.
 	RemoveID(context.Context, int64) error
 }
-
-// for tests we use generated mocks from these interfaces created with https://github.com/maxbrunsfeld/counterfeiter
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/aliases.go . AliasesService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/auth.go . AuthWithSSBService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/auth_fallback.go . AuthFallbackService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/denied.go . DeniedKeysService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/fixed_pages.go . PinnedNoticesService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/invites.go . InvitesService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/members.go . MembersService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/pages.go . NoticesService
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o mockdb/roomconfig.go . RoomConfig


### PR DESCRIPTION
Stripped version on https://github.com/ssbc/go-ssb-room/pull/291. It's easier for me to have confidence merging this change set than try to navigate the potential breakages and behaviour changes in https://github.com/ssbc/go-ssb-room/pull/291. Hope y'all don't mind! Don't really have a lot of hands on deck for maintenance, so I'm trying to make smaller changes...

This PR includes generation of armhf/arm64 binaries for the room server & `insert-user` tool. It also has a `counterfeiter` tweak to speed up the builds and includes some documentation on how to generate a new `dist/` which I just ran through.

I also ran into some `go-muxrpc` x-platform issues which I (hopefully) resolved in linked issues/PRs.

Thanks to @ahdinosaur for the original PR!