### PR TITLE
Add a JSON endpoint for generating invites

### DIFF
--- a/web/handlers/http.go
+++ b/web/handlers/http.go
@@ -364,7 +364,7 @@ func New(
 	m.Get(router.CompleteInviteFacadeFallback).Handler(r.HTML("invite/facade-fallback.tmpl", ih.presentFacadeFallback))
 	m.Get(router.CompleteInviteInsertID).Handler(r.HTML("invite/insert-id.tmpl", ih.presentInsert))
 	m.Get(router.CompleteInviteConsume).HandlerFunc(ih.consume)
-	m.Get(router.OpenModeCreateInvite).HandlerFunc(r.HTML("admin/invite-created.tmpl", ih.createOpenMode))
+	m.Get(router.OpenModeCreateInvite).HandlerFunc(ih.createOpenMode)
 
 	// static assets
 	m.PathPrefix("/assets/").Handler(http.StripPrefix("/assets/", http.FileServer(web.Assets)))
@@ -379,6 +379,7 @@ func New(
 	mainMux.Handle("/", m)
 
 	consumeURL := urlTo(router.CompleteInviteConsume)
+	openModeCreateInviteURL := urlTo(router.OpenModeCreateInvite)
 
 	// apply HTTP middleware
 	middlewares := []func(http.Handler) http.Handler{
@@ -391,6 +392,10 @@ func New(
 			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				ct := req.Header.Get("Content-Type")
 				if req.URL.Path == consumeURL.Path && ct == "application/json" {
+					next.ServeHTTP(w, csrf.UnsafeSkipCheck(req))
+					return
+				}
+				if req.URL.Path == openModeCreateInviteURL.Path && req.Header.Get("Accept") == "application/json" {
 					next.ServeHTTP(w, csrf.UnsafeSkipCheck(req))
 					return
 				}

--- a/web/router/complete.go
+++ b/web/router/complete.go
@@ -44,7 +44,7 @@ func CompleteApp() *mux.Router {
 	m.Path("/members/change-password").Methods("GET").Name(MembersChangePasswordForm)
 	m.Path("/members/change-password").Methods("POST").Name(MembersChangePassword)
 
-	m.Path("/create-invite").Methods("GET").Name(OpenModeCreateInvite)
+	m.Path("/create-invite").Methods("GET", "POST").Name(OpenModeCreateInvite)
 	m.Path("/join").Methods("GET").Name(CompleteInviteFacade)
 	m.Path("/join-fallback").Methods("GET").Name(CompleteInviteFacadeFallback)
 	m.Path("/join-manually").Methods("GET").Name(CompleteInviteInsertID)


### PR DESCRIPTION
When running in open mode invites can be freely generated by accessing /create-invite. This displays an HTML page which creates and displays an invite to the user.

This commit adds an additional way of creating invites in open mode. A POST request can be sent to the same /create-invite endpoint with the Accept header set to application/json. This returns a JSON response which contains an invite url.

The purpose of this change is to make automatic invite generation easier in SSB clients.